### PR TITLE
sort jason configuration

### DIFF
--- a/lib/resource.ex
+++ b/lib/resource.ex
@@ -44,6 +44,10 @@ defmodule AshJason.Resource do
         type: {:fun, [:map, :map], :map},
         doc: "A function to customize json. Receives a current result and a resource record.",
       ],
+      order: [
+        type: {:list, :atom},
+        doc: "Ordered list of keys to appear in the encoded output"
+      ]
     ],
   }
 

--- a/lib/resource.ex
+++ b/lib/resource.ex
@@ -47,6 +47,10 @@ defmodule AshJason.Resource do
       order: [
         type: {:list, :atom},
         doc: "Ordered list of keys to appear in the encoded output"
+      ],
+      sort: [
+        type: {:fun, [:map, :map], :map},
+        doc: "A function to sort keys. Receives keys and a resource record.",
       ]
     ],
   }

--- a/test/ash_jason_test.exs
+++ b/test/ash_jason_test.exs
@@ -150,4 +150,20 @@ defmodule AshJason.Test do
       assert encode!(%WithCustomize{id: @id, x: 1, y: 1}) == "{\"id\":\"#{@id}\",\"c\":1,\"x\":1}"
     end
   end
+
+  describe "`order` option" do
+    defresource WithPickMergeOrder do
+      jason do
+        pick [:y, :z]
+        merge %{x: 3}
+        order [:x, :y, :z]
+      end
+    end
+
+    test "ordered map" do
+      assert encode!(%WithPickMergeOrder{z: 2, y: 1}) == "{\"x\":3,\"y\":1,\"z\":2}"
+      assert encode!(%WithPickMergeOrder{y: 1, z: 2}) == "{\"x\":3,\"y\":1,\"z\":2}"
+      assert encode!(%WithPickMergeOrder{y: 1}) == "{\"x\":3,\"y\":1}"
+    end
+  end
 end

--- a/test/ash_jason_test.exs
+++ b/test/ash_jason_test.exs
@@ -152,6 +152,8 @@ defmodule AshJason.Test do
   end
 
   describe "`order` option" do
+
+
     defresource WithPickMergeOrder do
       jason do
         pick [:y, :z]
@@ -164,6 +166,31 @@ defmodule AshJason.Test do
       assert encode!(%WithPickMergeOrder{z: 2, y: 1}) == "{\"x\":3,\"y\":1,\"z\":2}"
       assert encode!(%WithPickMergeOrder{y: 1, z: 2}) == "{\"x\":3,\"y\":1,\"z\":2}"
       assert encode!(%WithPickMergeOrder{y: 1}) == "{\"x\":3,\"y\":1}"
+    end
+  end
+
+  describe "`sort` option" do
+    defresource WithSortDescending do
+      jason do
+        pick [:x, :y, :z]
+        sort fn keys, _record ->
+          keys |> Enum.sort(:desc)
+        end
+      end
+    end
+
+    defresource WithSortAscending do
+      jason do
+        pick [:x, :y, :z]
+        sort fn keys, _record ->
+          keys |> Enum.sort()
+        end
+      end
+    end
+
+    test "ordered map with custom sort" do
+      assert encode!(%WithSortAscending{z: 2, x: 3, y: 1}) == "{\"x\":3,\"y\":1,\"z\":2}"
+      assert encode!(%WithSortDescending{x: 3, y: 1, z: 2}) == "{\"z\":2,\"y\":1,\"x\":3}"
     end
   end
 end


### PR DESCRIPTION
Dmitry, I have pull request with order, this includes that and sort, which allows the sort order of the keys to customised in a function. The default sorting function doesn't sort, which allows you to either take the keys from result, or from order if present and then run the function.

I haven't done Spark before and I wasn't able to build the schema the way you wanted it, feel free to change it.
