### PR TITLE
Update ex_check dependency to dev and test only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule AshJason.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:sourceror, "~> 1.7", only: [:dev, :test], runtime: false},
       {:freedom_formatter, "~> 2.1", only: [:dev, :test], runtime: false},
-      {:ex_check, "~> 0.16.0"},
+      {:ex_check, "~> 0.16.0", only: [:dev, :test], runtime: false},
     ]
   end
 


### PR DESCRIPTION
Without this check, applications that depend on ash_jason unwittingly also have `ex_check` as a dependency.